### PR TITLE
fix: filename in project

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,7 +38,7 @@ s.register_setting('dd.impfs', json.dumps(setting))
 def export_db(bv):
     """Export symbols and optionally comments from Binary Ninja to an x64dbg database."""
     db = dict()
-    module = pathlib.Path(bv.file.original_filename)
+    module = pathlib.Path(get_filename(bv))
     outpath = bv.file.database.globals.get('x64dbg_db_save_path', pathlib.Path(bv.file.filename).parent)
     dbext = 'dd{}'.format(bv.arch.address_size * 8)
 
@@ -79,7 +79,7 @@ def export_db(bv):
 
 def import_db(bv):
     """Import x64dbg database to Binary Ninja."""
-    module = pathlib.Path(bv.file.original_filename).name.lower()
+    module = pathlib.Path(get_filename(bv)).name.lower()
 
     if not (f := get_open_filename_input('Import database', '*.dd{}'.format(bv.arch.default_int_size * 8))):
         return
@@ -119,6 +119,23 @@ def import_db(bv):
     logger.log_debug('Comment(s) imported: {}/{}'.format(count, len(comments)))
 
     logger.log_info('Done!')
+
+
+def get_filename(bv):
+    """Returns the original filename for the current view."""
+    if bv.project is not None:
+        return get_filename_for_project_file(bv, bv.file.original_filename)
+
+    return bv.file.original_filename
+
+
+def get_filename_for_project_file(bv, project_file_name):
+    """Returns the original filename of a project file"""
+    for file in bv.project.files:
+        if file.path_on_disk == project_file_name:
+            return file.name
+
+    return None
 
 
 def is_valid(bv):


### PR DESCRIPTION
Use the correct filename instead of the UUID when using projects.


Fixes:
 > The module name is based on the file name which is a UUID when using Projects.  

#17